### PR TITLE
Replacing the unquote import and replacing the unquoting of the messa…

### DIFF
--- a/myfreecams.py
+++ b/myfreecams.py
@@ -2,8 +2,8 @@ import logging
 import random
 import re
 import uuid
+import urllib.parse
 
-from streamlink.compat import unquote
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents, validate
@@ -180,7 +180,7 @@ class MyFreeCams(Plugin):
                     buff = ''.join(socket_buffer)
                     break
 
-                message = unquote(message)
+                message = urllib.parse.unquote(message, encoding='utf-8', errors='replace')
 
                 if FCTYPE == 1 and username:
                     ws.send('10 0 0 20 0 {0}\n'.format(username))


### PR DESCRIPTION
Replacing the unquote import and replacing the unquoting of the message with the new function.

I was getting this error when trying to use your plugin.

ImportError: cannot import name 'unquote' from 'streamlink.compat' (C: \Program Files (x86)\Streamlink\pkgs\streamlink\compat.py)

Seeing as though the current streamlink compat.py file has nothing including unquote and I tried the suggested fixes found on google (re install master branch and all that), I figured I would just try fixing it myself.

Works just fine on my end.

(sorry if this is too lengthy or whatever, this is my first ever commit/pull request and I practically have no idea what I'm doing. amazed this actually worked to be honest)
